### PR TITLE
Add possibility to pass in `envelop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ With help of the great library [`graphql-helix`](https://github.com/contrawork/g
 - Have one schema, resolve some things in your DO, others in the Worker
 - Add middlewares and context
 - Live subscriptions (over [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events))
+- Easy to use with [`envelop`](https://github.com/dotansimha/envelop)
 - Full type safety with Typescript
 
 ## Upcoming
@@ -180,6 +181,29 @@ const [emit, resolver] = createSubscription({
 
 // Now you can simply just emit the following
 emit('This is a new comment 💬')
+```
+
+### Usage with [`envelop`](https://github.com/dotansimha/envelop)
+
+```ts
+import helixFlare from 'helix-flare/envelop'
+import { envelop, useSchema } from '@envelop/core'
+
+const schema = `…`
+
+const getEnvelopedFn = envelop({
+  plugins: [
+    useSchema(schema),
+    // add other envelop plugins here…
+  ],
+})
+
+// worker
+export default {
+  fetch(request: Request) {
+    return helixFlare(request, getEnvelopedFn)
+  },
+}
 ```
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "graphql-helix"
   ],
   "dependencies": {
+    "@envelop/core": "1.6.2",
     "event-iterator": "^2",
     "graphql": "^15",
     "graphql-helix": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,24 @@
   ],
   "description": "GraphQL Helix for your Cloudflare Workers",
   "type": "module",
-  "module": "./dist/index.js",
   "main": "./dist/index.cjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "./*": {
+      "import": "./dist/*.js",
+      "require": "./dist/*.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/index.d.ts"
+      ],
+      "envelop": [
+        "dist/envelop.d.ts"
+      ]
+    }
+  },
   "engines": {
     "node": ">=16"
   },
@@ -36,8 +51,10 @@
     "cloudflare-workers",
     "graphql-helix"
   ],
+  "peerDependencies": {
+    "@envelop/core": "1.6.2"
+  },
   "dependencies": {
-    "@envelop/core": "1.6.2",
     "event-iterator": "^2",
     "graphql": "^15",
     "graphql-helix": "1.10.2",
@@ -45,6 +62,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.2.0",
+    "@envelop/core": "1.6.2",
     "@graphql-tools/schema": "^8.3.1",
     "@graphql-tools/wrap": "^8.3.1",
     "@types/jest": "27.0.3",
@@ -56,7 +74,7 @@
     "miniflare": "2.0.0-rc.2",
     "nanoevents": "6.0.2",
     "patch-package": "^6.4.7",
-    "prettier": "^2.4.1",
+    "prettier": "^2.5.0",
     "source-map-support": "^0.5.21",
     "tiny-glob": "0.2.9",
     "ts-jest": "^27.0.7",

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,73 @@
+import {
+  getGraphQLParameters,
+  getMultipartResponse,
+  processRequest,
+  renderGraphiQL,
+  shouldRenderGraphiQL,
+} from 'graphql-helix'
+
+import { createAccessHeaders } from './utils/createAccessHeaders'
+import type { CreateAccessHeadersOptions } from './utils/createAccessHeaders'
+import { createHelixRequest } from './utils/createHelixRequest'
+import type { ProcessRequestOptions } from 'graphql-helix'
+import getPushResponseSSE from './sse/getPushResponseSSE'
+import getResponse from './utils/getResponse'
+
+type Options = { request: Request; access?: CreateAccessHeadersOptions } & Pick<
+  ProcessRequestOptions<any, any>,
+  'parse' | 'validate' | 'contextFactory' | 'execute' | 'schema'
+>
+
+const core = async <TContext>({
+  request,
+  schema,
+  parse,
+  validate,
+  execute,
+  contextFactory,
+  access,
+}: Options) => {
+  const cors = createAccessHeaders(access)
+  const { isPreflight, headers } = cors(request)
+
+  if (isPreflight) {
+    return new Response(null, { status: 204, headers })
+  }
+
+  const helixRequest = await createHelixRequest(request)
+
+  if (shouldRenderGraphiQL(helixRequest)) {
+    return new Response(renderGraphiQL(), {
+      headers: { 'Content-Type': 'text/html' },
+    })
+  } else {
+    const { operationName, query, variables } =
+      getGraphQLParameters(helixRequest)
+
+    const result = await processRequest({
+      operationName,
+      query,
+      variables,
+      request: helixRequest,
+      schema,
+      parse,
+      validate,
+      execute,
+      contextFactory,
+    })
+
+    switch (result.type) {
+      case 'RESPONSE':
+        return getResponse(result, headers)
+      case 'PUSH':
+        // @todo cors headers
+        return getPushResponseSSE(result, request)
+      case 'MULTIPART_RESPONSE':
+        return getMultipartResponse(result, Response, ReadableStream as any)
+      default:
+        return new Response('Not supported.', { status: 405 })
+    }
+  }
+}
+
+export default core

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,12 +4,14 @@ import {
   processRequest,
   renderGraphiQL,
   shouldRenderGraphiQL,
+  type ProcessRequestOptions,
 } from 'graphql-helix'
 
-import { createAccessHeaders } from './utils/createAccessHeaders'
-import type { CreateAccessHeadersOptions } from './utils/createAccessHeaders'
+import {
+  createAccessHeaders,
+  type CreateAccessHeadersOptions,
+} from './utils/createAccessHeaders'
 import { createHelixRequest } from './utils/createHelixRequest'
-import type { ProcessRequestOptions } from 'graphql-helix'
 import getPushResponseSSE from './sse/getPushResponseSSE'
 import getResponse from './utils/getResponse'
 

--- a/src/createExecutor.ts
+++ b/src/createExecutor.ts
@@ -1,6 +1,8 @@
-import { observableToAsyncIterable } from '@graphql-tools/utils'
+import {
+  observableToAsyncIterable,
+  type AsyncExecutor,
+} from '@graphql-tools/utils'
 import { print } from 'graphql'
-import type { AsyncExecutor } from '@graphql-tools/utils'
 
 import { fetchEventSource } from './sse/fetchEventSource'
 import getArguments from './utils/getArguments'

--- a/src/envelop.ts
+++ b/src/envelop.ts
@@ -1,5 +1,6 @@
 import type { CreateAccessHeadersOptions } from './utils/createAccessHeaders'
 import type { GetEnvelopedFn } from '@envelop/core'
+
 import core from './core'
 
 type Options = {
@@ -9,7 +10,7 @@ type Options = {
 const helixFlareEnvelop = async <PluginsContext extends any>(
   request: Request,
   getEnveloped: GetEnvelopedFn<PluginsContext>,
-  { access }: Options,
+  { access }: Options | undefined = {},
 ) => {
   const { schema, parse, validate, execute, contextFactory } = getEnveloped({
     req: request,

--- a/src/envelop.ts
+++ b/src/envelop.ts
@@ -9,10 +9,10 @@ type Options = {
 
 const helixFlareEnvelop = async <PluginsContext extends any>(
   request: Request,
-  getEnveloped: GetEnvelopedFn<PluginsContext>,
+  getEnvelopedFn: GetEnvelopedFn<PluginsContext>,
   { access }: Options | undefined = {},
 ) => {
-  const { schema, parse, validate, execute, contextFactory } = getEnveloped({
+  const { schema, parse, validate, execute, contextFactory } = getEnvelopedFn({
     req: request,
   })
 

--- a/src/envelop.ts
+++ b/src/envelop.ts
@@ -1,0 +1,29 @@
+import type { CreateAccessHeadersOptions } from './utils/createAccessHeaders'
+import type { GetEnvelopedFn } from '@envelop/core'
+import core from './core'
+
+type Options = {
+  access?: CreateAccessHeadersOptions
+}
+
+const helixFlareEnvelop = async <PluginsContext extends any>(
+  request: Request,
+  getEnveloped: GetEnvelopedFn<PluginsContext>,
+  { access }: Options,
+) => {
+  const { schema, parse, validate, execute, contextFactory } = getEnveloped({
+    req: request,
+  })
+
+  return core({
+    request,
+    schema,
+    parse,
+    validate,
+    execute,
+    contextFactory,
+    access,
+  })
+}
+
+export default helixFlareEnvelop

--- a/src/helix-flare.ts
+++ b/src/helix-flare.ts
@@ -1,20 +1,10 @@
-import {
-  getGraphQLParameters,
-  getMultipartResponse,
-  processRequest,
-  renderGraphiQL,
-  shouldRenderGraphiQL,
-} from 'graphql-helix'
+import type { ProcessRequestOptions } from 'graphql-helix'
+import type { IMiddleware } from 'graphql-middleware'
 import { applyMiddleware } from 'graphql-middleware'
 import type { GraphQLSchema } from 'graphql'
-import type { IMiddleware } from 'graphql-middleware'
 
-import { createAccessHeaders } from './utils/createAccessHeaders'
 import type { CreateAccessHeadersOptions } from './utils/createAccessHeaders'
-import { createHelixRequest } from './utils/createHelixRequest'
-import type { ProcessRequestOptions } from 'graphql-helix'
-import getPushResponseSSE from './sse/getPushResponseSSE'
-import getResponse from './utils/getResponse'
+import core from './core'
 
 type Options<TContext> = {
   access?: CreateAccessHeadersOptions
@@ -27,44 +17,12 @@ const helixFlare = async <TContext>(
   schema: GraphQLSchema,
   { middlewares = [], access, contextFactory }: Options<TContext> = {},
 ) => {
-  const cors = createAccessHeaders(access)
-  const { isPreflight, headers } = cors(request)
-
-  if (isPreflight) {
-    return new Response(null, { status: 204, headers })
-  }
-
-  const helixRequest = await createHelixRequest(request)
-
-  if (shouldRenderGraphiQL(helixRequest)) {
-    return new Response(renderGraphiQL(), {
-      headers: { 'Content-Type': 'text/html' },
-    })
-  } else {
-    const { operationName, query, variables } =
-      getGraphQLParameters(helixRequest)
-
-    const result = await processRequest({
-      operationName,
-      query,
-      variables,
-      request: helixRequest,
-      schema: applyMiddleware(schema, ...middlewares),
-      contextFactory,
-    })
-
-    switch (result.type) {
-      case 'RESPONSE':
-        return getResponse(result, headers)
-      case 'PUSH':
-        // @todo cors headers
-        return getPushResponseSSE(result, request)
-      case 'MULTIPART_RESPONSE':
-        return getMultipartResponse(result, Response, ReadableStream as any)
-      default:
-        return new Response('Not supported.', { status: 405 })
-    }
-  }
+  return core({
+    request,
+    schema: applyMiddleware(schema, ...middlewares),
+    contextFactory,
+    access,
+  })
 }
 
 export default helixFlare

--- a/src/helix-flare.ts
+++ b/src/helix-flare.ts
@@ -1,6 +1,5 @@
+import { applyMiddleware, type IMiddleware } from 'graphql-middleware'
 import type { ProcessRequestOptions } from 'graphql-helix'
-import type { IMiddleware } from 'graphql-middleware'
-import { applyMiddleware } from 'graphql-middleware'
 import type { GraphQLSchema } from 'graphql'
 
 import type { CreateAccessHeadersOptions } from './utils/createAccessHeaders'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export { default as default } from './helix-flare'
-export { default as helixFlareEnvelop } from './envelop'
 export { createExecutor } from './createExecutor'
 export { createSubscription, STOP } from './createSubscription'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as default } from './helix-flare'
+export { default as helixFlareEnvelop } from './envelop'
 export { createExecutor } from './createExecutor'
 export { createSubscription, STOP } from './createSubscription'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,5 +5,5 @@ export const tsup: Options = {
   clean: true,
   target: 'node16',
   format: ['esm', 'cjs'],
-  entryPoints: ['src/index.ts'],
+  entryPoints: ['src/index.ts', 'src/envelop.ts'],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,10 +2974,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
+  integrity sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==
 
 pretty-format@^27.0.0, pretty-format@^27.3.1:
   version "27.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,6 +307,18 @@
   resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.2.0.tgz#df300466f5f8a03b205bdd533990017b0538496e"
   integrity sha512-y0+f7QeB5/fMMdU0wSwvBB18yE9kAD2s7Wben8a4uI4f/EJyE+eJrai5QO52Pq8EmWP0vRpKqZh0qU857WhY2A==
 
+"@envelop/core@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-1.6.2.tgz#03e80b01cd0faaca0e1d0a406a14d6693c6dbd84"
+  integrity sha512-otrNSlMgR0e8xG2tHI5Lcsg4YWKdUngRBn/dhxzTK2KFOOQa4mEfQI5k3/hESFlC8WFbP2pvNmegPjxa7aK4eA==
+  dependencies:
+    "@envelop/types" "1.5.1"
+
+"@envelop/types@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-1.5.1.tgz#8a47ca9f6e78b40b176dac0dea6c5045f92c644d"
+  integrity sha512-NrwLVzyNqiSzgRRqOxkU2IgRc5hSGS73VsgxqchU3jl36rYo7AXVAnITkytmB9wk+jN2vUOVvayLkaTXooARwg==
+
 "@graphql-tools/batch-execute@^8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz#0b74c54db5ac1c5b9a273baefc034c2343ebbb74"


### PR DESCRIPTION
This makes it possible to use `envelop` to use in `helix-flare`. Just use the `helix-flare/envelop` import:

```ts
import helixFlare from 'helix-flare/envelop'
import { envelop } from '@envelop/core'

const getEnvelopedFn = envelop(…)
// …
// in worker
return helixFlare(request, getEnvelopedFn)
```

