### PR TITLE
Avoid wasteful request cloning

### DIFF
--- a/src/helix-flare.ts
+++ b/src/helix-flare.ts
@@ -16,7 +16,7 @@ type Options<TContext> = SharedOptions & {
 
 export const shouldRenderGraphiQL = async (request: Request) => {
   try {
-    return helixShouldRenderGraphiQL(await createHelixRequest(request))
+    return helixShouldRenderGraphiQL(request)
   } catch {
     return false
   }

--- a/src/utils/createHelixRequest.ts
+++ b/src/utils/createHelixRequest.ts
@@ -3,7 +3,7 @@ export const createHelixRequest = async (request: Request) => {
   const query = Object.fromEntries(new URLSearchParams(url.search))
 
   const body =
-    request.method === 'POST' ? await request.clone().json() : undefined
+    request.method === 'POST' ? await request.json() : undefined
 
   return {
     body,


### PR DESCRIPTION
[wrangler2](https://github.com/cloudflare/wrangler2)'s `wrangler dev` displays the following warning message repeated for each request to workers and sub-requests to durable objects:

> Your worker called response.clone(), but did not read the body of both clones. This is wasteful, as it forces the system to buffer the entire response body in memory, rather than streaming it through. This may cause your worker to be unexpectedly terminated for going over the memory limit. If you only meant to copy the response headers and metadata (e.g. in order to be able to modify them), use `new Response(response.body, response)` instead.

This PR fixes the issue by avoiding use of `request.clone()`. Body parsing is not required for `shouldRenderGraphiQL()` and CF Request's `.method` and `.headers` APIs are compatible with [graphql-helix](https://github.com/contra/graphql-helix)'s `shouldRenderGraphiQL()`, so we can pass the original request instead. Cloning request should be optional for users of `helix-flare` not only to avoid this warning message but also for performance reasons as described in the message above.